### PR TITLE
Add model-bakery support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,9 @@ jobs:
         django-version:
           # we don't need to support version that haven't deprecated CIText
           - "4.2"  # LTS
+        extras:
+          - ""
+          - "bakery"
         include:
           - python-version: "3.x"
             django-version: "latest"
@@ -76,6 +79,8 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - run: python -m pip install .[test]
+    - run: python -m pip install .[${{ matrix.extras }}]
+      if: matrix.extras != ''
     - run: python -m pip install django~=${{ matrix.django-version }}.0
       if: matrix.django-version != 'latest'
     - run: python -m pip install git+https://github.com/django/django.git@main#egg=django

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,9 +69,6 @@ jobs:
         extras:
           - ""
           - "bakery"
-        include:
-          - python-version: "3.x"
-            django-version: "latest"
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/citext/__init__.py
+++ b/citext/__init__.py
@@ -1,6 +1,5 @@
 """PostgreSQL CIText integration for Django."""
 
-from . import baker_generators  # noqa
 from . import _version
 from .fields import *  # noqa
 from .operations import *  # noqa

--- a/citext/__init__.py
+++ b/citext/__init__.py
@@ -1,5 +1,6 @@
 """PostgreSQL CIText integration for Django."""
 
+from . import baker_generators  # noqa
 from . import _version
 from .fields import *  # noqa
 from .operations import *  # noqa

--- a/citext/baker_generators.py
+++ b/citext/baker_generators.py
@@ -7,10 +7,8 @@ https://github.com/model-bakers/model_bakery/
 try:
     from model_bakery import baker, random_gen
 except ImportError:
-    baker = None
-
-
-if baker:
+    pass
+else:
     baker.generators.add("citext.fields.CICharField", random_gen.gen_string)
     baker.generators.add("citext.fields.CIEmailField", random_gen.gen_email)
     baker.generators.add("citext.fields.CITextField", random_gen.gen_text)

--- a/citext/baker_generators.py
+++ b/citext/baker_generators.py
@@ -1,0 +1,16 @@
+"""
+Extends model_bakery's generators to support citext fields.
+
+This logic is loaded only if package model_bakery is installed.
+https://github.com/model-bakers/model_bakery/
+"""
+try:
+    from model_bakery import baker, random_gen
+except ImportError:
+    baker = None
+
+
+if baker:
+    baker.generators.add("citext.fields.CICharField", random_gen.gen_string)
+    baker.generators.add("citext.fields.CIEmailField", random_gen.gen_email)
+    baker.generators.add("citext.fields.CITextField", random_gen.gen_text)

--- a/citext/fields.py
+++ b/citext/fields.py
@@ -35,3 +35,6 @@ for field in CIText.__subclasses__():
         field.register_lookup(lookup)
 
     field.register_lookup(lookups.IsNull)
+
+
+from . import baker_generators  # noqa

--- a/citext/fields.py
+++ b/citext/fields.py
@@ -1,5 +1,6 @@
 from django.db import models
 
+from . import baker_generators  # noqa
 from . import lookups
 
 __all__ = ["CICharField", "CIEmailField", "CIText", "CITextField"]

--- a/citext/fields.py
+++ b/citext/fields.py
@@ -1,6 +1,5 @@
 from django.db import models
 
-from . import baker_generators  # noqa
 from . import lookups
 
 __all__ = ["CICharField", "CIEmailField", "CIText", "CITextField"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ test = [
   "pytest",
   "pytest-cov",
   "pytest-django",
+  "model-bakery",
 ]
 psycopg2 = ["psycopg2-binary"]
 
@@ -64,7 +65,7 @@ DJANGO_SETTINGS_MODULE = "tests.testapp.settings"
 
 [tool.coverage.run]
 source = ["citext"]
-omit = ["citext/buildapi.py"]
+omit = ["citext/baker_generators.py"]
 
 [tool.coverage.report]
 show_missing = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,9 +43,9 @@ test = [
   "pytest",
   "pytest-cov",
   "pytest-django",
-  "model-bakery",
 ]
 psycopg2 = ["psycopg2-binary"]
+bakery = ["model-bakery"]
 
 [project.urls]
 Project-URL = "https://github.com/voiio/citext"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,6 @@ DJANGO_SETTINGS_MODULE = "tests.testapp.settings"
 
 [tool.coverage.run]
 source = ["citext"]
-omit = ["citext/baker_generators.py"]
 
 [tool.coverage.report]
 show_missing = true

--- a/tests/test_baker_generators.py
+++ b/tests/test_baker_generators.py
@@ -1,9 +1,7 @@
-import pytest
 from model_bakery import baker
 
 from tests.testapp import models
 
 
-@pytest.mark.django_db
 def test_generators():
     assert baker.prepare(models.TestModel)

--- a/tests/test_baker_generators.py
+++ b/tests/test_baker_generators.py
@@ -1,0 +1,9 @@
+import pytest
+from model_bakery import baker
+
+from tests.testapp import models
+
+
+@pytest.mark.django_db
+def test_generators():
+    assert baker.prepare(models.TestModel)

--- a/tests/test_baker_generators.py
+++ b/tests/test_baker_generators.py
@@ -1,7 +1,8 @@
-from model_bakery import baker
+import pytest
 
 from tests.testapp import models
 
 
 def test_generators():
+    baker = pytest.importorskip("model_bakery.baker")
     assert baker.prepare(models.TestModel)


### PR DESCRIPTION
Since the model-bakery package is widely adopted and we at @voiio are using it, it would make sense to introduce [generators](https://model-bakery.readthedocs.io/en/latest/how_bakery_behaves.html#custom-fields) supporting CI fields.
